### PR TITLE
feat(security): Ensure UTF-8 GitHub signature verification

### DIFF
--- a/src/main/java/com/deploymyapp/build_scheduler/controller/GithubEventController.java
+++ b/src/main/java/com/deploymyapp/build_scheduler/controller/GithubEventController.java
@@ -1,6 +1,7 @@
 package com.deploymyapp.build_scheduler.controller;
 
 import java.security.MessageDigest;
+import java.nio.charset.StandardCharsets;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -62,11 +63,11 @@ public class GithubEventController {
         }
         try {
             Mac hmac = Mac.getInstance("HmacSHA256");
-            SecretKeySpec key = new SecretKeySpec(secret.getBytes(), "HmacSHA256");
+            SecretKeySpec key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
             hmac.init(key);
-            String expectedHex = Hex.encodeHexString(hmac.doFinal(payload.getBytes()));
-            String receivedHex = signature256.substring("sha256=".length());
-            return MessageDigest.isEqual(expectedHex.getBytes(), receivedHex.getBytes());
+            byte[] expected = hmac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+            byte[] received = Hex.decodeHex(signature256.substring("sha256=".length()).toCharArray());
+            return MessageDigest.isEqual(expected, received);
         } catch (Exception e) {
             return false;
         }

--- a/src/test/java/com/deploymyapp/build_scheduler/controller/GithubEventControllerTest.java
+++ b/src/test/java/com/deploymyapp/build_scheduler/controller/GithubEventControllerTest.java
@@ -1,0 +1,41 @@
+package com.deploymyapp.build_scheduler.controller;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.commons.codec.binary.Hex;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestTemplate;
+
+import com.deploymyapp.build_scheduler.controller.GithubEventController;
+import com.deploymyapp.build_scheduler.controller.GithubProperties;
+
+class GithubEventControllerTest {
+
+    @Test
+    void validatesSignatureCorrectly() throws Exception {
+        String payload = "{\"some\":\"payload\"}";
+        String secret = "test-secret";
+
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+        String signature = "sha256=" + Hex.encodeHexString(mac.doFinal(payload.getBytes(StandardCharsets.UTF_8)));
+
+        GithubEventController controller = new GithubEventController(new GithubProperties(), new RestTemplate());
+        Method m = GithubEventController.class.getDeclaredMethod("isSignatureValid", String.class, String.class, String.class);
+        m.setAccessible(true);
+
+        boolean valid = (boolean) m.invoke(controller, payload, signature, secret);
+        assertTrue(valid);
+
+        boolean invalid = (boolean) m.invoke(controller, payload, signature + "0", secret);
+        assertFalse(invalid);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Compare webhook signatures in constant time using UTF-8 encoding
- Add unit test for GitHub webhook signature validation

## Testing
- `./mvnw test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_68a25a537b6c8331a0f0483bcc014e1b